### PR TITLE
added spacer

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@ nav: false
       <a href="http://opentechschool.org/materials.html">and other languages</a>
 
     </div>
+    <div class="spacer" style="clear: both;"></div>
   </div>
 </div>
 


### PR DESCRIPTION
According to http://stackoverflow.com/questions/218760/how-do-you-keep-parents-of-floated-elements-from-collapsing
you can add a spacer to keep left and right aligned columns from collapsing.

The problem was that you could not click the links in the left and right column above the Python for Beginners Workshop because the Python for Beginners was above them. With the spacer, I added a height to the two divs and now you can click them again.

Compare: http://niccokunzmann.github.io/python/ (clickable)
To: http://opentechschool.github.io/python/ (not clickable)
